### PR TITLE
fix(stage8.2): prefer explicit append content from issue

### DIFF
--- a/.github/scripts/agent_issue_executor.py
+++ b/.github/scripts/agent_issue_executor.py
@@ -2084,6 +2084,107 @@ def build_step5_skip_message(file_path: str, reason: str) -> str:
 """
 
 
+def extract_explicit_append_content(
+    issue_body: str,
+    existing_plan: str,
+    file_path: str
+) -> dict:
+    """从 Issue 正文或 Stage 1 计划中提取明确的追加内容
+
+    提取优先级：
+    1. Issue 正文中匹配文件类型的代码块（如 ```gitignore）
+    2. Issue 正文中通用代码块（如 ```）
+    3. Stage 1 plan 中匹配文件类型的代码块
+    4. Stage 1 plan 中通用代码块
+    5. 没有明确内容时，返回 found=False
+
+    Args:
+        issue_body: Issue 正文内容
+        existing_plan: Stage 1 生成的计划内容
+        file_path: 目标文件路径
+
+    Returns:
+        dict: {
+            'found': bool,
+            'content': str,
+            'source': str  # 'issue_body_code_block', 'issue_body_generic_block', 'plan_code_block', 'plan_generic_block'
+        }
+    """
+    import re
+
+    # 确定目标代码块的语言标记
+    file_path_normalized = file_path.replace('\\', '/').lower()
+    basename = file_path_normalized.split('/')[-1]
+
+    if basename == '.gitignore':
+        preferred_lang = 'gitignore'
+    elif basename == '.env.example':
+        preferred_lang = 'env'
+    else:
+        preferred_lang = None
+
+    # 提取函数
+    def extract_code_blocks(text: str) -> list:
+        """从文本中提取所有代码块及其类型"""
+        # 匹配 ```lang ... ``` 格式的代码块
+        pattern = r'```(\w*)?\n(.*?)```'
+        matches = re.findall(pattern, text, re.DOTALL)
+        return matches
+
+    # 优先级 1: Issue 正文中的代码块
+    if issue_body:
+        issue_blocks = extract_code_blocks(issue_body)
+
+        # 优先查找匹配文件类型的代码块
+        if preferred_lang:
+            for lang, content in issue_blocks:
+                if lang.lower() == preferred_lang:
+                    return {
+                        'found': True,
+                        'content': content.strip(),
+                        'source': 'issue_body_code_block'
+                    }
+
+        # 兜底：使用通用代码块
+        for lang, content in issue_blocks:
+            if content.strip():
+                return {
+                    'found': True,
+                    'content': content.strip(),
+                    'source': 'issue_body_generic_block'
+                }
+
+    # 优先级 2: Stage 1 plan 中的代码块
+    if existing_plan:
+        plan_blocks = extract_code_blocks(existing_plan)
+
+        # 优先查找匹配文件类型的代码块
+        if preferred_lang:
+            for lang, content in plan_blocks:
+                if lang.lower() == preferred_lang:
+                    return {
+                        'found': True,
+                        'content': content.strip(),
+                        'source': 'plan_code_block'
+                    }
+
+        # 兜底：使用通用代码块
+        for lang, content in plan_blocks:
+            if content.strip():
+                return {
+                    'found': True,
+                    'content': content.strip(),
+                    'source': 'plan_generic_block'
+                }
+
+    # 优先级 5: 没有找到明确的代码块
+    return {
+        'found': False,
+        'content': '',
+        'source': None
+    }
+
+
 def execute_step5(g, repo, issue, issue_number: int) -> dict:
     """执行 Step 5 文件修改并提交
 
@@ -2233,14 +2334,33 @@ def execute_step5(g, repo, issue, issue_number: int) -> dict:
             'commit_sha': None
         }
 
-    # 对于配置文件，将 AI 生成的追加内容拼接到文件末尾
+    # 对于配置文件，优先使用 Issue/Plan 中明确的代码块内容
     if is_config:
         print(f"  📝 检测到配置文件，使用 append-only 模式")
         print(f"  📝 AI 生成的追加内容长度: {len(new_content)} 字符")
 
+        # 尝试从 Issue/Plan 中提取明确的代码块内容
+        print("🔍 尝试从 Issue/Plan 中提取明确的追加内容...")
+        explicit_result = extract_explicit_append_content(
+            issue_body=issue.body or "",
+            existing_plan=plan_content,
+            file_path=file_path
+        )
+
+        # 根据提取结果决定使用哪个内容
+        if explicit_result['found']:
+            append_text = explicit_result['content']
+            append_source = explicit_result['source']
+            print(f"  ✅ 发现明确的代码块内容，来源: {append_source}")
+            print(f"  📝 明确内容长度: {len(append_text)} 字符")
+        else:
+            append_text = new_content
+            append_source = "ai_generated"
+            print(f"  ℹ️  未发现明确的代码块，使用 AI 生成内容")
+
         # 验证追加内容是否安全
         print("🔍 验证追加内容安全性...")
-        append_validation = validate_append_content(file_path, new_content, current_content)
+        append_validation = validate_append_content(file_path, append_text, current_content)
 
         if not append_validation['valid']:
             print(f"  ❌ 追加内容验证失败: {append_validation['reason']}")
@@ -2254,10 +2374,10 @@ def execute_step5(g, repo, issue, issue_number: int) -> dict:
                 'commit_sha': None
             }
 
-        print(f"  ✅ 追加内容安全验证通过")
+        print(f"  ✅ 追加内容安全验证通过 (内容来源: {append_source})")
 
         # 追加内容到文件末尾（使用安全的追加函数）
-        final_content = append_to_file_content(current_content, new_content)
+        final_content = append_to_file_content(current_content, append_text)
 
         print(f"  ✅ 追加后的文件内容长度: {len(final_content)} 字符")
         print(f"  📊 追加了 {len(final_content) - len(current_content)} 字符")

--- a/.github/scripts/test_stage8_2_validation.py
+++ b/.github/scripts/test_stage8_2_validation.py
@@ -23,6 +23,7 @@ from agent_issue_executor import (
     construct_modification_objective,
     validate_append_content,
     append_to_file_content,
+    extract_explicit_append_content,
 )
 from agent_issue_handler import (
     is_safe_path as handler_is_safe_path,
@@ -344,6 +345,148 @@ def test_append_to_file_content():
     print("  ✅ append_to_file_content() 测试通过\n")
 
 
+def test_extract_explicit_append_content():
+    """测试显式内容提取函数"""
+    print("🧪 测试 extract_explicit_append_content()...")
+
+    # 测试 1：从 Issue body 中提取 .gitignore 代码块（优先级最高）
+    print("  📝 测试 1：Issue body 中的 .gitignore 代码块（优先级最高）")
+    issue_body_1 = """
+请追加以下忽略规则：
+```gitignore
+*.stage82.log
+*.temp
+```
+"""
+    plan_1 = "## 计划\n\n### 计划修改文件\n- `.gitignore` - 追加忽略规则"
+    result1 = extract_explicit_append_content(issue_body_1, plan_1, ".gitignore")
+    assert result1['found'] == True, "❌ 应该找到代码块"
+    assert result1['source'] == 'issue_body_code_block', "❌ 应该是 issue_body_code_block"
+    assert "*.stage82.log" in result1['content'], "❌ 应该包含 *.stage82.log"
+    print("    ✅ Issue body .gitignore 代码块正确提取")
+
+    # 测试 2：从 Stage 1 计划中提取 .env.example 代码块（次优先级）
+    print("  📝 测试 2：Stage 1 计划中的 .env.example 代码块（次优先级）")
+    issue_body_2 = "请追加环境变量"
+    plan_2 = """
+## 计划
+
+### 计划修改文件
+- `.env.example` - 追加环境变量
+
+### 执行内容
+```env
+NEW_VARIABLE=example_value
+ANOTHER_VAR=another_value
+```
+"""
+    result2 = extract_explicit_append_content(issue_body_2, plan_2, ".env.example")
+    assert result2['found'] == True, "❌ 应该找到代码块"
+    assert result2['source'] == 'plan_code_block', "❌ 应该是 plan_code_block"
+    assert "NEW_VARIABLE=example_value" in result2['content'], "❌ 应该包含新变量"
+    print("    ✅ Stage 1 计划 .env.example 代码块正确提取")
+
+    # 测试 3：通用代码块提取（无语言标记）
+    print("  📝 测试 3：通用代码块提取（无语言标记）")
+    issue_body_3 = """
+请在 .gitignore 中追加：
+```
+*.log
+*.tmp
+temp/
+```
+"""
+    plan_3 = "## 计划\n\n### 计划修改文件\n- `.gitignore` - 追加忽略规则"
+    result3 = extract_explicit_append_content(issue_body_3, plan_3, ".gitignore")
+    assert result3['found'] == True, "❌ 应该找到代码块"
+    assert result3['source'] == 'issue_body_generic_block', "❌ 应该是 issue_body_generic_block"
+    assert "*.log" in result3['content'], "❌ 应该包含 *.log"
+    print("    ✅ 通用代码块正确提取")
+
+    # 测试 4：多个代码块时选择第一个匹配的
+    print("  📝 测试 4：多个代码块时选择第一个匹配的")
+    issue_body_4 = """
+第一个代码块：
+```python
+print("ignore this")
+```
+
+第二个代码块：
+```gitignore
+*.first
+*.second
+```
+
+第三个代码块：
+```gitignore
+*.third
+```
+"""
+    plan_4 = "## 计划\n\n### 计划修改文件\n- `.gitignore` - 追加忽略规则"
+    result4 = extract_explicit_append_content(issue_body_4, plan_4, ".gitignore")
+    assert result4['found'] == True, "❌ 应该找到代码块"
+    assert "*.first" in result4['content'], "❌ 应该选择第一个匹配的代码块"
+    assert "*.third" not in result4['content'], "❌ 不应该包含第三个代码块"
+    print("    ✅ 多个代码块正确选择第一个")
+
+    # 测试 5：无代码块时返回 not found
+    print("  📝 测试 5：无代码块时返回 not found")
+    issue_body_5 = "请在 .gitignore 中追加 *.log 文件"
+    plan_5 = "## 计划\n\n### 计划修改文件\n- `.gitignore` - 追加 *.log"
+    result5 = extract_explicit_append_content(issue_body_5, plan_5, ".gitignore")
+    assert result5['found'] == False, "❌ 无代码块时应该返回 not found"
+    assert result5['content'] == "", "❌ 内容应该为空"
+    assert result5['source'] is None, "❌ 来源应该为 None"
+    print("    ✅ 无代码块时正确返回 not found")
+
+    # 测试 6：Issue body 空时从 Stage 1 计划提取
+    print("  📝 测试 6：Issue body 空时从 Stage 1 计划提取")
+    issue_body_6 = ""
+    plan_6 = """
+## 计划
+
+### 计划修改文件
+- `.env.example` - 追加环境变量
+
+### 追加内容
+```env
+FALLBACK_VAR=fallback_value
+```
+"""
+    result6 = extract_explicit_append_content(issue_body_6, plan_6, ".env.example")
+    assert result6['found'] == True, "❌ 应该从 Stage 1 计划找到代码块"
+    assert result6['source'] == 'plan_code_block', "❌ 应该是 plan_code_block"
+    assert "FALLBACK_VAR=fallback_value" in result6['content'], "❌ 应该包含回退变量"
+    print("    ✅ 从 Stage 1 计划正确提取")
+
+    # 测试 7：优先级验证（Issue body 优先于 Stage 1 计划）
+    print("  📝 测试 7：优先级验证（Issue body 优先于 Stage 1 计划）")
+    issue_body_7 = """
+```gitignore
+*.issue_body
+```
+"""
+    plan_7 = """
+## 计划
+
+### 计划修改文件
+- `.gitignore` - 追加忽略规则
+
+### 追加内容
+```gitignore
+*.plan_content
+```
+"""
+    result7 = extract_explicit_append_content(issue_body_7, plan_7, ".gitignore")
+    assert result7['found'] == True, "❌ 应该找到代码块"
+    assert result7['source'] == 'issue_body_code_block', "❌ Issue body 应该优先于 Stage 1 计划"
+    assert "*.issue_body" in result7['content'], "❌ 应该使用 Issue body 的内容"
+    assert "*.plan_content" not in result7['content'], "❌ 不应该使用 Stage 1 计划的内容"
+    print("    ✅ 优先级正确验证")
+
+    print("  ✅ extract_explicit_append_content() 测试通过\n")
+
+
 if __name__ == "__main__":
     try:
         print("="*60)
@@ -357,6 +500,7 @@ if __name__ == "__main__":
         test_validate_first_file_with_config()
         test_validate_append_content()
         test_append_to_file_content()
+        test_extract_explicit_append_content()
 
         print("="*60)
         print("✅ 所有本地逻辑测试通过")


### PR DESCRIPTION
## Summary

Fix Stage 8.2 append-only behavior.

The previous flow allowed AI to freely generate append content. In Issue #34, the user explicitly requested:

```gitignore
*.stage82.log
```

But the generated PR appended unrelated local config rules instead.

This PR adds `extract_explicit_append_content()` and makes the config append-only flow prefer explicit code blocks from the Issue body or Stage 1 plan before falling back to AI-generated content.

## Validation

Local checks passed:

```bash
uv run python .github/scripts/test_stage8_2_validation.py
bash .github/scripts/verify_agent_setup.sh
```

## Files changed

- `.github/scripts/agent_issue_executor.py`
- `.github/scripts/test_stage8_2_validation.py`