### PR TITLE
fix(stage8.2): pass existing plan into append extractor

### DIFF
--- a/.github/scripts/agent_issue_executor.py
+++ b/.github/scripts/agent_issue_executor.py
@@ -2343,7 +2343,7 @@ def execute_step5(g, repo, issue, issue_number: int) -> dict:
         print("🔍 尝试从 Issue/Plan 中提取明确的追加内容...")
         explicit_result = extract_explicit_append_content(
             issue_body=issue.body or "",
-            existing_plan=plan_content,
+            existing_plan=existing_plan or "",
             file_path=file_path
         )
 

--- a/.github/scripts/test_stage8_2_validation.py
+++ b/.github/scripts/test_stage8_2_validation.py
@@ -484,6 +484,17 @@ FALLBACK_VAR=fallback_value
     assert "*.plan_content" not in result7['content'], "❌ 不应该使用 Stage 1 计划的内容"
     print("    ✅ 优先级正确验证")
 
+    # 测试 8：existing_plan 为空字符串时不会报错（bugfix 验证）
+    print("  📝 测试 8：existing_plan 为空字符串时不会报错")
+    issue_body_8 = "请在 .gitignore 中追加 *.log"
+    plan_8 = ""  # 空 existing_plan
+    result8 = extract_explicit_append_content(issue_body_8, plan_8, ".gitignore")
+    # 空 existing_plan 应该不报错，只是找不到代码块
+    assert result8['found'] == False, "❌ 空 existing_plan 应该返回 not found"
+    assert result8['content'] == "", "❌ 内容应该为空"
+    assert result8['source'] is None, "❌ 来源应该为 None"
+    print("    ✅ 空 existing_plan 不报错")
+
     print("  ✅ extract_explicit_append_content() 测试通过\n")
 
 


### PR DESCRIPTION
## Summary

Fix Stage 8.2 append-only execution failure.

During Issue #34 retest, Stage 5 failed with:

```text
name 'plan_content' is not defined
```

## Root Cause

`execute_step5()` called `extract_explicit_append_content()` with an undefined variable:

```python
existing_plan=plan_content
```

But the real Stage 1 plan variable in the function is:

```python
existing_plan
```

## Fix

Changed the call to:

```python
existing_plan=existing_plan or ""
```

Also added a regression test to ensure empty `existing_plan` does not crash append content extraction.

## Validation

Local checks passed:

```bash
uv run python .github/scripts/test_stage8_2_validation.py
bash .github/scripts/verify_agent_setup.sh
python -m py_compile .github/scripts/agent_issue_executor.py
```

## Files changed

- `.github/scripts/agent_issue_executor.py`
- `.github/scripts/test_stage8_2_validation.py`