### PR TITLE
Stage 8.4: Stage 1 敏感内容前置识别

### DIFF
--- a/.github/scripts/agent_issue_handler.py
+++ b/.github/scripts/agent_issue_handler.py
@@ -542,6 +542,162 @@ def validate_first_file_exists(plan: str, repo) -> tuple[bool, str]:
         return False, f"文件 `{first_file}` 在仓库中不存在。请重新在 Issue 中评论 `@zhipu` 生成正确的计划。"
 
 
+def extract_plan_append_content(plan: str) -> Optional[str]:
+    """从 Stage 1 plan 的 ### 计划追加内容 章节中提取 fenced code block 内容
+
+    Args:
+        plan: Stage 1 生成的完整计划内容
+
+    Returns:
+        str: 提取的代码块内容，如果未找到则返回 None
+    """
+    if not plan:
+        return None
+
+    # 查找 "### 计划追加内容" 章节
+    lines = plan.split('\n')
+    in_target_section = False
+    code_block_content = []
+    in_code_block = False
+
+    for line in lines:
+        # 检测是否进入目标章节
+        if "### 计划追加内容" in line:
+            in_target_section = True
+            continue
+
+        # 如果进入目标章节，开始提取代码块
+        if in_target_section:
+            # 检测代码块开始
+            if line.strip().startswith('```'):
+                if not in_code_block:
+                    in_code_block = True
+                    continue
+                else:
+                    # 代码块结束
+                    break
+
+            # 如果在代码块内，收集内容
+            if in_code_block:
+                code_block_content.append(line)
+
+            # 遇到下一个章节标题，停止查找
+            if line.strip().startswith('###') and not in_code_block:
+                break
+
+    # 如果找到代码块内容，返回
+    if code_block_content:
+        return '\n'.join(code_block_content).strip()
+
+    return None
+
+
+def validate_plan_append_content_safety(plan: str) -> tuple[bool, str]:
+    """对 Stage 1 plan 中的 append-only 追加内容做轻量安全检查
+
+    只做前置提醒和明显风险拦截。
+    Stage 5 的 validate_append_content() 仍然是最终强校验。
+
+    检查规则：
+    1. 只针对包含 "### 操作类型" 和 "append-only" 的 plan
+    2. 只针对包含 "### 计划追加内容" 的 plan
+    3. 检测常见密钥前缀：sk-、ghp_、github_pat_、AIza
+    4. 允许安全的占位符：your_*、example_*、test_*、dummy、placeholder、xxx
+
+    Args:
+        plan: Stage 1 生成的完整计划内容
+
+    Returns:
+        tuple[bool, str]: (是否通过, 错误信息)
+    """
+    if not plan:
+        return True, ""  # 空 plan 允许通过（后续流程会处理）
+
+    # 检查是否为 append-only 任务
+    if "### 操作类型" not in plan:
+        return True, ""  # 没有 "### 操作类型" 章节，不是 append-only 任务
+
+    if "append-only" not in plan.lower():
+        return True, ""  # 不是 append-only 任务
+
+    # 提取追加内容
+    append_content = extract_plan_append_content(plan)
+
+    if not append_content:
+        # 没有 "### 计划追加内容" 或没有代码块，允许通过（后续流程会处理）
+        return True, ""
+
+    # 转换为小写用于检测
+    append_content_lower = append_content.lower()
+
+    # 检测明显的真实密钥前缀
+    dangerous_patterns = [
+        ('sk-', 'OpenAI API key'),
+        ('ghp_', 'GitHub personal access token'),
+        ('github_pat_', 'GitHub personal access token (fine-grained)'),
+        ('AIza', 'Google API key'),
+    ]
+
+    # 先检查危险前缀（如果有危险前缀，直接拒绝）
+    for pattern, desc in dangerous_patterns:
+        if pattern.lower() in append_content_lower:
+            # 构建详细的错误提示
+            error_msg = f"""## ⚠️ Stage 1 计划验证失败
+
+**检测到疑似真实密钥**
+
+追加内容中包含疑似真实密钥前缀：`{pattern}`（{desc}）
+
+**安全提示**：
+- ⚠️ 请不要把真实密钥写入 Issue、代码或 .env.example
+- ⚠️ 真实密钥应该存储在本地 .env 文件中（已在 .gitignore 中）
+- ⚠️ .env.example 应该只包含安全的占位符
+
+**正确示例**：
+```env
+OPENAI_API_KEY=your_openai_api_key_here
+ZHIPU_API_KEY=your-zhipu-api-key-here
+GITHUB_TOKEN=your_github_token_here
+GOOGLE_API_KEY=your_google_api_key_here
+TEST_KEY=example_value
+```
+
+**请按以下步骤修正**：
+1. 修改 Issue 内容，使用安全的占位符替换真实密钥
+2. 重新评论 `@zhipu` 生成新的计划
+
+---
+🤖 由 Zhipu AI Stage 1 安全校验生成 | {os.getenv('REPO', '')}"""
+            return False, error_msg
+
+    # 如果没有危险前缀，再检查是否包含安全的占位符（作为额外验证）
+    # 注意：这个检查只在调试时有用，实际逻辑是"没有危险前缀就允许"
+    safe_placeholders = [
+        'your_api_key_here',
+        'your-openai-api-key-here',
+        'your-zhipu-api-key-here',
+        'your_',
+        'example_value',
+        'example-key',
+        'placeholder',
+        'test_key',
+        'test-key',
+        'dummy',
+        'changeme',
+        'replace',
+    ]
+
+    # 检查是否包含明显的占位符（仅用于日志，不影响结果）
+    for placeholder in safe_placeholders:
+        if placeholder.lower() in append_content_lower:
+            # 包含明显的占位符，认为是安全的
+            return True, ""
+
+    # 未检测到明显的危险前缀，允许通过
+    # 即使没有明显的占位符，也允许通过（可能是自定义的值）
+    return True, ""
+
+
 def main() -> None:
     """主函数"""
     print("🚀 Zhipu Issue Agent 启动...")
@@ -623,6 +779,17 @@ def main() -> None:
         sys.exit(1)
 
     print("✅ 文件验证通过")
+
+    # 验证 append-only 追加内容的安全性
+    print("🔍 验证追加内容安全性...")
+    is_safe, safety_error = validate_plan_append_content_safety(ai_response)
+    if not is_safe:
+        print(f"❌ 追加内容安全验证失败: 检测到疑似真实密钥", file=sys.stderr)
+        # 在 Issue 中回复错误信息
+        issue.create_comment(safety_error)
+        sys.exit(1)
+
+    print("✅ 追加内容安全验证通过")
 
     try:
         issue.create_comment(ai_response)

--- a/.github/scripts/test_stage8_2_validation.py
+++ b/.github/scripts/test_stage8_2_validation.py
@@ -30,6 +30,8 @@ from agent_issue_handler import (
     is_supported_markdown_file as handler_is_supported_markdown_file,
     is_supported_append_only_config_file as handler_is_supported_append_only_config_file,
     validate_first_file_exists,
+    extract_plan_append_content,
+    validate_plan_append_content_safety,
 )
 
 # Mock GitHub Repository 对象
@@ -498,6 +500,186 @@ FALLBACK_VAR=fallback_value
     print("  ✅ extract_explicit_append_content() 测试通过\n")
 
 
+def make_test_plan(operation_type: str, append_content: str) -> str:
+    """构造测试用的 Stage 1 plan
+
+    Args:
+        operation_type: 操作类型（如 "append-only" 或 ""）
+        append_content: 追加内容（会放在代码块中）
+
+    Returns:
+        str: 构造的 plan
+    """
+    if operation_type:
+        return f"""
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `.env.example` - 追加环境变量
+
+### 操作类型
+{operation_type}
+
+### 计划追加内容
+```env
+{append_content}
+```
+"""
+    else:
+        return f"""
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `README.md` - 更新文档
+
+### Todo List
+- [ ] 更新文档
+"""
+
+
+def test_extract_plan_append_content():
+    """测试从 Stage 1 plan 中提取追加内容"""
+    print("🧪 测试 extract_plan_append_content()...")
+
+    # 测试 1：提取 .gitignore 追加内容
+    result1 = extract_plan_append_content("""
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `.gitignore` - 追加忽略规则
+
+### 操作类型
+append-only
+
+### 计划追加内容
+```gitignore
+*.stage84.log
+*.tmp
+```
+""")
+    assert result1 is not None and "*.stage84.log" in result1 and "*.tmp" in result1
+    print("  ✅ 提取 .gitignore 内容")
+
+    # 测试 2：提取 .env.example 追加内容
+    result2 = extract_plan_append_content("""
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `.env.example` - 追加环境变量示例
+
+### 操作类型
+append-only
+
+### 计划追加内容
+```env
+STAGE84_TEST_KEY=example_value
+ANOTHER_KEY=your_api_key_here
+```
+""")
+    assert result2 is not None and "STAGE84_TEST_KEY=example_value" in result2
+    print("  ✅ 提取 .env.example 内容")
+
+    # 测试 3：没有追加内容章节
+    result3 = extract_plan_append_content("""
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `README.md` - 更新文档
+
+### Todo List
+- [ ] 更新 README
+""")
+    assert result3 is None
+    print("  ✅ 没有追加内容章节返回 None")
+
+    # 测试 4：有章节但没有代码块
+    result4 = extract_plan_append_content("""
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `.gitignore` - 追加忽略规则
+
+### 操作类型
+append-only
+
+### 计划追加内容
+*.log
+""")
+    assert result4 is None
+    print("  ✅ 没有代码块返回 None")
+
+    # 测试 5：空 plan
+    result5 = extract_plan_append_content("")
+    assert result5 is None
+    print("  ✅ 空 plan 返回 None")
+
+    print("  ✅ extract_plan_append_content() 测试通过\n")
+
+
+def test_validate_plan_append_content_safety():
+    """测试 Stage 1 追加内容安全校验"""
+    print("🧪 测试 validate_plan_append_content_safety()...")
+
+    # 测试危险前缀（sk-, ghp_, github_pat_, AIza）
+    dangerous_prefixes = [
+        ("sk-", "OPENAI_API_KEY=sk-test-real-secret-value"),
+        ("ghp_", "GITHUB_TOKEN=ghp_xxxxxxxxxxxxx"),
+        ("github_pat_", "GITHUB_PAT=github_pat_xxxxxxxxxxxxx"),
+        ("AIza", "GOOGLE_API_KEY=AIzaxxxxxxxxxxxxx"),
+    ]
+
+    for prefix, content in dangerous_prefixes:
+        plan = make_test_plan("append-only", content)
+        is_valid, error = validate_plan_append_content_safety(plan)
+        assert is_valid == False, f"{prefix} 应该被拒绝"
+        assert prefix in error, f"错误信息应包含 {prefix}"
+        assert "疑似真实密钥" in error, "错误信息应包含提示"
+        print(f"  ✅ {prefix} 前缀正确拒绝")
+
+    # 测试安全占位符
+    safe_placeholders = [
+        "OPENAI_API_KEY=your_openai_api_key_here",
+        "STAGE84_TEST_KEY=example_value",
+        "API_KEY_1=your_api_key_here",
+        "API_KEY_2=test_key",
+        "API_KEY_3=dummy",
+    ]
+
+    for content in safe_placeholders:
+        plan = make_test_plan("append-only", content)
+        is_valid, error = validate_plan_append_content_safety(plan)
+        assert is_valid == True, f"{content} 应该允许"
+        assert error == "", "错误信息应该为空"
+    print("  ✅ 安全占位符正确允许")
+
+    # 测试非 append-only plan
+    plan_non_append = make_test_plan("", "")
+    is_valid, error = validate_plan_append_content_safety(plan_non_append)
+    assert is_valid == True and error == ""
+    print("  ✅ 非 append-only plan 正确跳过")
+
+    # 测试没有追加内容
+    plan_no_append = """
+## 🤖 Zhipu Fix Plan
+
+### 计划修改文件
+- `.gitignore` - 追加忽略规则
+
+### 操作类型
+append-only
+"""
+    is_valid, error = validate_plan_append_content_safety(plan_no_append)
+    assert is_valid == True and error == ""
+    print("  ✅ 没有追加内容正确跳过")
+
+    # 测试空 plan
+    is_valid, error = validate_plan_append_content_safety("")
+    assert is_valid == True and error == ""
+    print("  ✅ 空 plan 正确跳过")
+
+    print("  ✅ validate_plan_append_content_safety() 测试通过\n")
+
+
 if __name__ == "__main__":
     try:
         print("="*60)
@@ -512,6 +694,8 @@ if __name__ == "__main__":
         test_validate_append_content()
         test_append_to_file_content()
         test_extract_explicit_append_content()
+        test_extract_plan_append_content()
+        test_validate_plan_append_content_safety()
 
         print("="*60)
         print("✅ 所有本地逻辑测试通过")


### PR DESCRIPTION
## 功能说明

在 Stage 1 计划生成阶段增加轻量安全校验，提前识别包含疑似真实密钥的 append-only 追加内容，避免用户等到 Stage 5 才被拒绝。

## 变更内容

### 新增函数

- `extract_plan_append_content()`：从 Stage 1 plan 中提取 `### 计划追加内容` 的代码块
- `validate_plan_append_content_safety()`：Stage 1 轻量安全检查

### 修改范围

- `.github/scripts/agent_issue_handler.py`
- `.github/scripts/test_stage8_2_validation.py`

## 核心能力

- 检测常见密钥前缀：`sk-`、`ghp_`、`github_pat_`、`AIza`
- 允许安全占位符：`your_*`、`example_value`、`test_key`、`dummy` 等
- 非 append-only plan 不触发校验
- Stage 1 失败时使用 `sys.exit(1)`，与现有验证失败行为保持一致
- Stage 5 的完整安全校验继续保留，作为最终兜底

## 测试验证

本地测试已通过：

```bash
uv run python .github/scripts/test_stage8_2_validation.py